### PR TITLE
Unet model path error

### DIFF
--- a/app.py
+++ b/app.py
@@ -278,4 +278,5 @@ def ui():
 
 
 demo = ui()
-demo.launch(share=True)
+#demo.launch(share=True)
+demo.launch()

--- a/src/models/unet_3d.py
+++ b/src/models/unet_3d.py
@@ -643,18 +643,22 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin):
 
         model = cls.from_config(unet_config, **unet_additional_kwargs)
         # load the vanilla weights
-        if str(pretrained_model_path).endswith(".safetensors"):
+        #if str(pretrained_model_path).endswith(".safetensors"):
+        if pretrained_model_path.joinpath(SAFETENSORS_WEIGHTS_NAME).exists():
             logger.debug(
                 f"loading safeTensors weights from {pretrained_model_path} ..."
             )
             state_dict = load_file(
-                pretrained_model_path, device="cpu"
+                #pretrained_model_path, device="cpu"
+                pretrained_model_path.joinpath(SAFETENSORS_WEIGHTS_NAME), device="cpu"
             )
 
-        elif str(pretrained_model_path).endswith(".ckpt"):
+        #elif str(pretrained_model_path).endswith(".ckpt"):
+        elif pretrained_model_path.joinpath(WEIGHTS_NAME).exists():
             logger.debug(f"loading weights from {pretrained_model_path} ...")
             state_dict = torch.load(
-                pretrained_model_path,
+                pretrained_model_path.joinpath(WEIGHTS_NAME),
+                #pretrained_model_path,
                 map_location="cpu",
                 weights_only=True,
             )


### PR DESCRIPTION
The `if str(pretrained_model_path).endswith(".safetensors")` and `elif str(pretrained_model_path).endswith(".ckpt"):` fail because the `pretrained_model_path` is NOT the model file path, but the `unet` folder path.

I got it to work by reverting back to the original code. Maybe I'm missing something, was there a specific reason for this change? Feel free to ignore the PR if I am missing something, just thought I would send the PR since I got it to work after changing these lines.

BTW, couldn't get it to work on Macs despite the code changes to properly support mps. Keep getting memory issues, any ideas?